### PR TITLE
Fix docker-provisioner for ubuntu 22.04

### DIFF
--- a/provisioner/docker/docker-compose-with-cgroupv2.yml
+++ b/provisioner/docker/docker-compose-with-cgroupv2.yml
@@ -25,3 +25,4 @@ services:
         - ./config/hiera.yaml:/etc/puppet/hiera.yaml
         - ./config/hieradata:/etc/puppet/hieradata
         - ./config/hosts:/etc/hosts
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/provisioner/docker/docker-compose.yml
+++ b/provisioner/docker/docker-compose.yml
@@ -25,4 +25,3 @@ services:
         - ./config/hiera.yaml:/etc/puppet/hiera.yaml
         - ./config/hieradata:/etc/puppet/hieradata
         - ./config/hosts:/etc/hosts
-        - /sys/fs/cgroup:/sys/fs/cgroup:ro


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/BIGTOP/How+to+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'BIGTOP-3638: Your PR title ...'.
-->

### Description of PR
Closes #10 

### How was this patch tested?
```bash
./gradlew -Pconfig=config_ubuntu-22.04.yaml -POS=ubuntu-22.04 -Pnum_instances=3 -Pprefix=3.2.1 docker-provisioner > tmp.log 2>&1
```