### PR TITLE
Change mtu for docker provisioner into 1450

### DIFF
--- a/provisioner/docker/docker-compose.yml
+++ b/provisioner/docker/docker-compose.yml
@@ -25,4 +25,9 @@ services:
         - ./config/hiera.yaml:/etc/puppet/hiera.yaml
         - ./config/hieradata:/etc/puppet/hieradata
         - ./config/hosts:/etc/hosts
-        - /sys/fs/cgroup:/sys/fs/cgroup:ro
+
+networks:
+    default:
+        driver: bridge
+        driver_opts:
+            com.docker.network.driver.mtu: 1450


### PR DESCRIPTION
### Description of PR
Server's network mtu parameter is 1450, but docker containers starts with 1500 by default. Because of this, timeout errors occur from time to time.


